### PR TITLE
Fix usage of Point.{X,Y}

### DIFF
--- a/secp256k1zkp/constants.go
+++ b/secp256k1zkp/constants.go
@@ -5,8 +5,8 @@
 package secp256k1zkp
 
 import (
-	//. "github.com/yoss22/bulletproofs"
-	//"math/big"
+	. "github.com/yoss22/bulletproofs"
+	"math/big"
 )
 
 const (
@@ -72,10 +72,10 @@ var (
 	}
 
 	// Generator G as a point.
-	/*G = Point{
+	G = Point{
 		X: new(big.Int).SetBytes(Gx),
 		Y: new(big.Int).SetBytes(Gy),
-	}*/
+	}
 
 	// Generator H
 	Hx = []byte{
@@ -92,10 +92,10 @@ var (
 	}
 
 	// Generator H as a point.
-	/*H = Point{
+	H = Point{
 		X: new(big.Int).SetBytes(Hx),
 		Y: new(big.Int).SetBytes(Hy),
-	}*/
+	}
 
 	// Generator J, for switch commitments (as compressed curve point (3))
 	GENERATOR_J = []byte{

--- a/secp256k1zkp/schnorr.go
+++ b/secp256k1zkp/schnorr.go
@@ -1,31 +1,6 @@
 package secp256k1zkp
 
 import (
-	"github.com/yoss22/bulletproofs"
-	"math/big"
-)
-
-// ComputeMessage encodes fee and lockHeight into a 32-byte message.
-func ComputeMessage(fee, lockHeight uint64) [32]byte {
-	return [32]byte{}
-}
-
-type Signature struct {
-	S big.Int
-	R bulletproofs.Point
-}
-
-func VerifySignature(publicKey bulletproofs.Point, message [32]byte, signature Signature) bool {
-	return false
-}
-
-func DecodeSignature(signature [64]byte) Signature {
-	return Signature{}
-}
-
-/*
-
-import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/binary"
@@ -209,4 +184,3 @@ func ComputeMessage(fee, lockHeight uint64) [32]byte {
 	binary.BigEndian.PutUint64(msg[24:], lockHeight)
 	return msg
 }
-*/


### PR DESCRIPTION
I have pushed those missing changes so everything builds properly again. This PR simply reverts the commenting out.

To verify I ran "go build ./..." and "go test ./..." and everything works again.

I also suggested versioning all the dependencies (issue #4). Let me know your opinions on that!