### PR TITLE
Update Proof.Hash to use ProofBytes

### DIFF
--- a/consensus/proof.go
+++ b/consensus/proof.go
@@ -48,7 +48,7 @@ func (p *Proof) ToDifficulty() Difficulty {
 
 // Hash returns hash of content pow
 func (p *Proof) Hash() []byte {
-	hash := blake2b.Sum256(p.Bytes())
+	hash := blake2b.Sum256(p.ProofBytes())
 	return hash[:]
 }
 


### PR DESCRIPTION
According to the official implementation, the bytes used for blake2b hash doesn't include edge_bits:

https://github.com/mimblewimble/grin/blob/99494c6fa67566859df6d9b6a3262d4c28a55f46/core/src/pow/types.rs#L433